### PR TITLE
Feature: Allow an ordinal variable with a float data type

### DIFF
--- a/ordinalcorr/corrmatrix.py
+++ b/ordinalcorr/corrmatrix.py
@@ -92,12 +92,14 @@ def is_cols_ordinal(data: pd.DataFrame, n_unique: int) -> list[bool]:
 
 def is_col_ordinal(x: pd.Series, n_unique: int) -> bool:
     """Check if the input is ordinal."""
-    if "int" in x.dtype.name.lower() and x.unique().size <= n_unique:
-        return True
 
     if x.dtype.name == "category":
         if x.cat.ordered:
             return True
         raise TypeError(f"The column '{x.name}' is unoredered category.")
+
+    # Judge by the number of unique values, even if the data type is 'float'
+    if x.unique().size <= n_unique:
+        return True
 
     return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ordinalcorr"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
     { name = "Masayoshi Mita", email = "nigimitama16@gmail.com" },
 ]

--- a/tests/test_hetcor.py
+++ b/tests/test_hetcor.py
@@ -1,9 +1,12 @@
 import unittest
 import numpy as np
 import pandas as pd
+from scipy.stats import multivariate_normal
 from ordinalcorr.corrmatrix import (
     hetcor,
     is_cols_ordinal,
+    polychoric,
+    polyserial,
 )
 
 
@@ -26,6 +29,42 @@ class TestHetcor(unittest.TestCase):
             ]
         )
         self.assertTrue(np.isclose(actual, expect, atol=1e-2).all())
+    
+    def test_with_synthetic_data(self):
+        multi_normal = generate_data()
+        data = pd.DataFrame(
+            {
+                "continuous": multi_normal["x1"],
+                "dichotomous": pd.cut(multi_normal["x2"], bins=2, labels=range(2)).astype(int),
+                "polytomous": pd.cut(multi_normal["x2"], bins=3, labels=range(2)).astype(int),
+            }
+        )
+        actual = hetcor(data).to_numpy()
+        r_cd = polyserial(data["continuous"], data["dichotomous"])
+        r_cp = polyserial(data["continuous"], data["polytomous"])
+        r_dp = polychoric(data["dichotomous"], data["polytomous"])
+        expect = np.array(
+            [
+                [1, r_cd, r_cp],
+                [r_cd, 1, r_dp],
+                [r_cp, r_dp, 1],
+            ]
+        )
+        self.assertTrue(np.isclose(actual, expect, atol=1e-5).all())
+
+
+def generate_data():
+    # Generate data by standard normal distribution
+    n = 500
+    rho=0.5
+    mean = [0, 0]
+    std = [1, 1]
+    cov = rho * std[0] * std[1]
+    Cov = np.array([[std[0] ** 2, cov], [cov, std[1] ** 2]])
+    X = multivariate_normal.rvs(mean=mean, cov=Cov, size=n, random_state=0)
+    df = pd.DataFrame(X, columns=["x1", "x2"])
+    return df
+
 
 
 class TestIsColsOrdinal(unittest.TestCase):
@@ -36,11 +75,12 @@ class TestIsColsOrdinal(unittest.TestCase):
             {
                 "continuous": np.repeat([0.1, 0.2, 0.3], 10),
                 "dichotomous": np.repeat([0, 1, 1], 10),
-                "polytomous": np.repeat([7, 5, 3], 10),
+                "polytomous_int": np.repeat([7, 5, 3], 10),
+                "polytomous_float": np.repeat([7.0, 5.0, 3.0], 10),
             }
         )
         actual = is_cols_ordinal(data, n_unique=10)
-        expected = [False, True, True]
+        expected = [False, True, True, True]
         self.assertEqual(list(actual), expected)
 
 

--- a/tests/test_hetcor.py
+++ b/tests/test_hetcor.py
@@ -73,7 +73,7 @@ class TestIsColsOrdinal(unittest.TestCase):
     def test_two_cols(self):
         data = pd.DataFrame(
             {
-                "continuous": np.repeat([0.1, 0.2, 0.3], 10),
+                "continuous": np.random.normal(size=30),
                 "dichotomous": np.repeat([0, 1, 1], 10),
                 "polytomous_int": np.repeat([7, 5, 3], 10),
                 "polytomous_float": np.repeat([7.0, 5.0, 3.0], 10),

--- a/tests/test_hetcor.py
+++ b/tests/test_hetcor.py
@@ -35,8 +35,8 @@ class TestHetcor(unittest.TestCase):
         data = pd.DataFrame(
             {
                 "continuous": multi_normal["x1"],
-                "dichotomous": pd.cut(multi_normal["x2"], bins=2, labels=range(2)).astype(int),
-                "polytomous": pd.cut(multi_normal["x2"], bins=3, labels=range(2)).astype(int),
+                "dichotomous": pd.cut(multi_normal["x2"], bins=2, labels=list(range(2))).astype(int),
+                "polytomous": pd.cut(multi_normal["x2"], bins=3, labels=list(range(3))).astype(int),
             }
         )
         actual = hetcor(data).to_numpy()


### PR DESCRIPTION
If the data type of a variable is 'float', even if the variable contains a small number of different values, it has been treated as a continuous variable.

This behaviour may be misleading because Pandas casts variables from 'int' to 'float' if they contain NA.

Therefore, such ordinal float variables should be allowed.